### PR TITLE
Added a payload property to MessageEntity and made sender nullable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "interactive-solutions/zf-user-message",
   "authors": [
     {
-      "name":  "Jonas Eriksson",
+      "name": "Jonas Eriksson",
       "email": "jonas.eriksson+git@interactivesolutions.se"
     },
     {
@@ -11,14 +11,8 @@
     }
   ],
   "require": {
-    "php":                          ">=5.5",
-    "zendframework/zendframework":  "~2.5",
-    "zfr/zfr-rest":                 "~0.5.0",
-    "doctrine/doctrine-orm-module": "~0.9.2",
-    "zf-commons/zfc-rbac":          "~2.3",
-    "interactive-solutions/zf-stdlib": "~0.0.1"
+    "php": ">=7.1",
   },
-
   "autoload": {
     "psr-0": {
       "InteractiveSolutions\\UserMessage\\": "src/"

--- a/config/doctrine/InteractiveSolutions.UserMessage.Entity.MessageEntity.dcm.xml
+++ b/config/doctrine/InteractiveSolutions.UserMessage.Entity.MessageEntity.dcm.xml
@@ -17,7 +17,7 @@
 
         <field name="createdAt" type="datetime" nullable="false"/>
         <field name="updatedAt" type="datetime" nullable="false"/>
-        <field name="payload" type="json_object" nullable="false"/>
+        <field name="payload" type="json_array" nullable="true"/>
         <field name="readByUsers" type="read_by_users" nullable="true"/>
 
         <many-to-one field="sender" target-entity="InteractiveSolutions\UserMessage\Entity\MessageUserInterface" fetch="EAGER">

--- a/config/doctrine/InteractiveSolutions.UserMessage.Entity.MessageEntity.dcm.xml
+++ b/config/doctrine/InteractiveSolutions.UserMessage.Entity.MessageEntity.dcm.xml
@@ -17,10 +17,11 @@
 
         <field name="createdAt" type="datetime" nullable="false"/>
         <field name="updatedAt" type="datetime" nullable="false"/>
+        <field name="payload" type="json_object" nullable="false"/>
         <field name="readByUsers" type="read_by_users" nullable="true"/>
 
         <many-to-one field="sender" target-entity="InteractiveSolutions\UserMessage\Entity\MessageUserInterface" fetch="EAGER">
-            <join-column on-delete="CASCADE" />
+            <join-column nullable="true" on-delete="CASCADE" />
         </many-to-one>
 
         <many-to-one target-entity="InteractiveSolutions\UserMessage\Entity\AbstractConversationEntity" field="conversation"

--- a/src/InteractiveSolutions/UserMessage/Entity/MessageEntity.php
+++ b/src/InteractiveSolutions/UserMessage/Entity/MessageEntity.php
@@ -38,7 +38,7 @@ class MessageEntity
     protected $readByUsers = [];
 
     /**
-     * @var array
+     * @var array|null
      */
     protected $payload;
 
@@ -65,9 +65,9 @@ class MessageEntity
         $this->updatedAt = new DateTime();
 
         $this->message = $data['message'] ?? '';
-        $this->payload = $data['payload'] ?? [];
+        $this->payload = $data['payload'] ?? null;
 
-        if (count($this->message) === 0 && count($this->payload) === 0) {
+        if (strlen($this->message) === 0 && $this->payload === null) {
             throw InvalidMessageException::emptyMessageAndPayload();
         }
 
@@ -113,9 +113,9 @@ class MessageEntity
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getPayload(): array
+    public function getPayload()
     {
         return $this->payload;
     }

--- a/src/InteractiveSolutions/UserMessage/Entity/MessageEntity.php
+++ b/src/InteractiveSolutions/UserMessage/Entity/MessageEntity.php
@@ -99,7 +99,7 @@ class MessageEntity
     /**
      * @return MessageUserInterface
      */
-    public function getSender(): MessageUserInterface
+    public function getSender(): ?MessageUserInterface
     {
         return $this->sender;
     }

--- a/src/InteractiveSolutions/UserMessage/Entity/MessageEntity.php
+++ b/src/InteractiveSolutions/UserMessage/Entity/MessageEntity.php
@@ -1,13 +1,14 @@
 <?php
 /**
- * @author Erik Norgren <erik.norgren@interactivesolutions.se>
- * @author Jonas Eriksson <jonas.eriksson@interactivesolutions.se>
+ * @author    Erik Norgren <erik.norgren@interactivesolutions.se>
+ * @author    Jonas Eriksson <jonas.eriksson@interactivesolutions.se>
  * @copyright Interactive Solutions
  */
 
 namespace InteractiveSolutions\UserMessage\Entity;
 
 use DateTime;
+use InteractiveSolutions\UserMessage\Exception\InvalidMessageException;
 
 class MessageEntity
 {
@@ -37,6 +38,11 @@ class MessageEntity
     protected $readByUsers = [];
 
     /**
+     * @var array
+     */
+    protected $payload;
+
+    /**
      * @var MessageUserInterface
      */
     protected $sender;
@@ -48,24 +54,31 @@ class MessageEntity
 
     /**
      * MessageEntity constructor.
+     *
      * @param AbstractConversationEntity $conversation
-     * @param MessageUserInterface $sender
-     * @param array $data
+     * @param MessageUserInterface       $sender
+     * @param array                      $data
      */
     public function __construct(AbstractConversationEntity $conversation, MessageUserInterface $sender, array $data)
     {
         $this->createdAt = new DateTime();
         $this->updatedAt = new DateTime();
 
-        $this->message      = $data['message'];
-        $this->conversation = $conversation;
+        $this->message = $data['message'] ?? '';
+        $this->payload = $data['payload'] ?? [];
+
+        if (count($this->message) === 0 && count($this->payload) === 0) {
+            throw InvalidMessageException::emptyMessageAndPayload();
+        }
+
         $this->sender       = $sender;
+        $this->conversation = $conversation;
     }
 
     /**
      * Add a ready by user entry
      *
-     * @param MessageEntity $instance
+     * @param MessageEntity   $instance
      * @param ReadByUserEntry $entry
      */
     public static function readByUser(MessageEntity $instance, ReadByUserEntry $entry)
@@ -78,7 +91,7 @@ class MessageEntity
     /**
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -86,7 +99,7 @@ class MessageEntity
     /**
      * @return MessageUserInterface
      */
-    public function getSender()
+    public function getSender(): MessageUserInterface
     {
         return $this->sender;
     }
@@ -94,15 +107,23 @@ class MessageEntity
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
     /**
+     * @return array
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    /**
      * @return DateTime
      */
-    public function getCreatedAt()
+    public function getCreatedAt(): DateTime
     {
         return $this->createdAt;
     }
@@ -110,7 +131,7 @@ class MessageEntity
     /**
      * @return DateTime
      */
-    public function getUpdatedAt()
+    public function getUpdatedAt(): DateTime
     {
         return $this->updatedAt;
     }
@@ -118,7 +139,7 @@ class MessageEntity
     /**
      * @return array
      */
-    public function getReadByUsers()
+    public function getReadByUsers(): array
     {
         return $this->readByUsers;
     }
@@ -126,16 +147,17 @@ class MessageEntity
     /**
      * @return AbstractConversationEntity
      */
-    public function getConversation()
+    public function getConversation(): AbstractConversationEntity
     {
         return $this->conversation;
     }
 
     /**
      * @param int $userId
+     *
      * @return bool
      */
-    private function hasRead(int $userId):bool
+    private function hasRead(int $userId): bool
     {
         /* @var ReadByUserEntry $entry */
         foreach ($this->readByUsers as $entry) {

--- a/src/InteractiveSolutions/UserMessage/Exception/ExceptionInterface.php
+++ b/src/InteractiveSolutions/UserMessage/Exception/ExceptionInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @author    Antoine Hedgecock <antoine.hedgecock@gmail.com>
+ *
+ * @copyright Interactive Solutions
+ */
+
+declare(strict_types = 1);
+
+namespace InteractiveSolutions\UserMessage\Exception;
+
+interface ExceptionInterface
+{
+
+}

--- a/src/InteractiveSolutions/UserMessage/Exception/InvalidMessageException.php
+++ b/src/InteractiveSolutions/UserMessage/Exception/InvalidMessageException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @author    Antoine Hedgecock <antoine.hedgecock@gmail.com>
+ *
+ * @copyright Interactive Solutions
+ */
+
+declare(strict_types = 1);
+
+namespace InteractiveSolutions\UserMessage\Exception;
+
+final class InvalidMessageException extends \RuntimeException implements ExceptionInterface
+{
+    public static function emptyMessageAndPayload(): self
+    {
+        return new self('Invalid message, either a message body or a payload must be specified');
+    }
+}


### PR DESCRIPTION
The payload property allows for adding meta data to the messages, we also made sender nullable. Doing this allows for combining system  messages without a sender and payload for meta data to do fun stuff in
the frontend.